### PR TITLE
Update Scrutinizer config to use the new PHP engine

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -127,17 +127,24 @@ build_failure_conditions:
     - 'project.metric("scrutinizer.quality", < 6)'
 
 build:
-    environment:
-        php: 7.2.22
-        
-    dependencies:
-        before:
-            - composer install
+    nodes:
+        analysis:
+            tests:
+                override:
+                    - php-scrutinizer-run
 
-    tests:
-        override:
-            -
-                command: ./vendor/bin/phpunit --process-isolation --whitelist src/ --coverage-clover /tmp/coverage.xml tests/
-                coverage:
-                    file: /tmp/coverage.xml
-                    format: php-clover
+        tests-and-coverage:
+            environment:
+                php: 7.2.22
+                
+            dependencies:
+                before:
+                    - composer install
+        
+            tests:
+                override:
+                    -
+                        command: ./vendor/bin/phpunit --process-isolation --whitelist src/ --coverage-clover /tmp/coverage.xml tests/
+                        coverage:
+                            file: /tmp/coverage.xml
+                            format: php-clover


### PR DESCRIPTION
### Fixed
- Update Scrutinizer config to use the new PHP engine
   * Details [here](https://scrutinizer-ci.com/docs/tools/php/php-analyzer/guides/migrate_to_new_php_analysis)