### PR TITLE
Release 3.2.0 -- allow null as the default in getArray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.phar
 .idea/
 local.env
 composer.lock
+.idea/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ environment variable's value can be split into an array automatically.
 
 ## Build Status
 
-![Unit Tests](https://github.com/silinternational/php-env/actions/workflows/tests.yml/badge.svg?branch=master)
+![Unit Tests](https://github.com/silinternational/php-env/actions/workflows/test.yml/badge.svg?branch=master)
 
 ## Setup
 

--- a/src/Env.php
+++ b/src/Env.php
@@ -123,12 +123,13 @@ class Env
     }
     
     /**
-     * 
-     * @param string $varname
-     * @param array $default
-     * @return array
+     * Get an array of data from an environment variable containing comma-separated values.
+     *
+     * @param string $varname The name of the desired environment variable.
+     * @param array|null $default The default value to return if the environment variable is not set.
+     * @return array|null
      */
-    public static function getArray($varname, array $default = [])
+    public static function getArray(string $varname, ?array $default = []): ?array
     {
         $value = self::get($varname);
         

--- a/tests/unit/EnvTest.php
+++ b/tests/unit/EnvTest.php
@@ -471,6 +471,18 @@ class EnvTest extends TestCase
         // Assert
         $this->fail("Should have thrown TypeError on default array.");
     }
+
+    public function testGetArray_notFoundWithNullDefault()
+    {
+        // Arrange
+        $varname = 'TESTGETARRAY_EXISTSWITHINVALIDDEFAULTTYPE';
+
+        // Act
+        $actual = Env::getArray($varname, null);
+
+        // Assert
+        $this->assertNull($actual);
+    }
     
     public function testGetArrayFromPrefix_multiple()
     {

--- a/tests/unit/EnvTest.php
+++ b/tests/unit/EnvTest.php
@@ -475,7 +475,7 @@ class EnvTest extends TestCase
     public function testGetArray_notFoundWithNullDefault()
     {
         // Arrange
-        $varname = 'TESTGETARRAY_EXISTSWITHINVALIDDEFAULTTYPE';
+        $varname = 'TESTGETARRAY_NOTFOUNDWITHNULLDEFAULT';
 
         // Act
         $actual = Env::getArray($varname, null);


### PR DESCRIPTION
### Added
- Make the `default` parameter in `getArray` nullable