### PR TITLE
Prevent orphan containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 test:
-	docker compose run test composer install
-	docker compose run test ./vendor/bin/phpunit --process-isolation tests/
+	docker compose run --rm test composer install
+	docker compose run --rm test ./vendor/bin/phpunit --process-isolation tests/
 
 testhost:
 	composer install --ignore-platform-reqs


### PR DESCRIPTION
The --rm flag was added to the run to make sure to remove the container after running it.